### PR TITLE
API de queima de cupom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,7 @@
-<<<<<<< HEAD
 * Deployment instructions
 
 * ...
 
-## API
-
-### Consulta de cupom
-
-#### GET /api/v1/coupons/:token
-
-**HTTP status:** 200
-
-```json
-
-{
-  "available": "Cupom válido",
-  "discount_rate": "100.0",
-  "monthly_duration": "6",
-  "expire_date_formatted": "09/09/2024",
-  "promotion": "Promoção de natal"
-}
-
-```
-
-```json
-
-{ 
-  "available": "Cupom expirado",
-  "discount_rate": "100.0",
-  "monthly_duration": "6",
-  "expire_date_formatted": "09/09/2024",
-  "promotion": "Promoção de natal"
-}
-
-```
-
-```json
-
-{
-  "available": "Cupom já utilizado",
-  "discount_rate": "100.0",
-  "monthly_duration": "6",
-  "expire_date_formatted": "09/09/2024",
-  "promotion": "Promoção de natal"
-}
-
-```
-
-**HTTP status:** 404
-
-```json
-{
-  "message": "Cupom não encontrado"
-}
-
-```
-=======
 ## API
 
 ### Consulta de CPF (/api/v1/partner_companies/search?q=CPF)
@@ -108,4 +54,106 @@ Enviado sem conteúdo
 ]
 ```
 
->>>>>>> eb4e7df25b5cae31e8a444ed402c375e720844d0
+### Consulta de cupom
+
+#### GET /api/v1/coupons/:token
+
+**HTTP status:** 200
+
+```json
+
+{
+  "available": "Cupom válido",
+  "discount_rate": "100.0",
+  "monthly_duration": "6",
+  "expire_date_formatted": "09/09/2024",
+  "promotion": "Promoção de natal"
+}
+
+```
+
+```json
+
+{ 
+  "available": "Cupom expirado",
+  "discount_rate": "100.0",
+  "monthly_duration": "6",
+  "expire_date_formatted": "09/09/2024",
+  "promotion": "Promoção de natal"
+}
+
+```
+
+```json
+
+{
+  "available": "Cupom já utilizado",
+  "discount_rate": "100.0",
+  "monthly_duration": "6",
+  "expire_date_formatted": "09/09/2024",
+  "promotion": "Promoção de natal"
+}
+
+```
+
+**HTTP status:** 404
+
+```json
+{
+  "message": "Cupom não encontrado"
+}
+
+```
+### Queima de cupom
+
+#### POST '/api/v1/coupon_burn'
+
+#### Parâmetros:
+
+```json
+{
+  "token": "BFRIDAY001"
+}
+
+```
+
+**HTTP status:** 200
+
+```json
+{}
+
+```
+
+#### Parâmetros:
+
+```json
+{}
+
+```
+
+**HTTP status:** 412
+
+```json
+{
+  "message": "Token inválido"
+}
+
+```
+
+#### Parâmetros:
+
+```json
+{
+  "token": "BANANA"
+}
+
+```
+
+**HTTP status:** 412
+
+```json
+{
+  "message": "Token inválido"
+}
+
+```

--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::CouponsController < Api::V1::ApiController
   end
 
   def burn
-    @coupon = Coupon.find_by!(token: params[:token])
+    @coupon = Coupon.find_by!(consumed: false, token: params[:token])
     @coupon.consumed = true
     @coupon.save
     render status: :ok

--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::CouponsController < Api::V1::ApiController
   def show
-    @coupon = Coupon.find(params[:token])
+    @coupon = Coupon.find_by!(token: params[:token])
     render json: @coupon.as_json(only: [], methods: :available,
                                  include: { promotion: { methods: :expire_date_formatted,
                                                          only: %i[discount_rate monthly_duration name] } }), status: :ok
@@ -9,11 +9,11 @@ class Api::V1::CouponsController < Api::V1::ApiController
   end
 
   def burn
-    @coupon = Coupon.find_by(token: params[:token])
-    return render json: { message: 'Token inválido' }, status: :precondition_failed if @coupon.blank?
-
+    @coupon = Coupon.find_by!(token: params[:token])
     @coupon.consumed = true
     @coupon.save
     render status: :ok
+  rescue ActiveRecord::RecordNotFound
+    render status: :precondition_failed, json: { message: 'Token inválido' }
   end
 end

--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -7,4 +7,13 @@ class Api::V1::CouponsController < Api::V1::ApiController
   rescue ActiveRecord::RecordNotFound
     render status: :not_found, json: { message: 'Cupom não encontrado' }
   end
+
+  def burn
+    @coupon = Coupon.find_by(token: params[:token])
+    return render json: { message: 'Token inválido' }, status: :precondition_failed if @coupon.blank?
+
+    @coupon.consumed = true
+    @coupon.save
+    render status: :ok
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
       resources :partner_companies do
         get 'search', on: :collection
       end
+      post 'coupon_burn', to: 'coupons#burn'
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,14 +8,14 @@ create(:partner_company_employee, cpf: '279.270.153-62', partner_company: partne
 promo_niver = create(:promotion, name: 'Promoção de aniversário',
                                  description: 'Ganhe 20% de desconto na matrícula no mês de aniversário Esperto Fit.',
                                  discount_rate: 20, coupon_quantity: 2, monthly_duration: 1,
-                                 expire_date: Date.parse('09/11/2020'),
+                                 expire_date: Date.parse('09/11/2030'),
                                  token: 'PROMONIVER')
 create(:coupon, token: 'PROMONIVER001', promotion: promo_niver)
 create(:coupon, token: 'PROMONIVER002', promotion: promo_niver)
 promo_verao = create(:promotion, name: 'Promoção de verão',
                                  description: 'Ganhe 10% de desconto em produtos das filiais.',
                                  discount_rate: 10, coupon_quantity: 2, monthly_duration: 2,
-                                 expire_date: Date.parse('09/10/2020'),
+                                 expire_date: Date.parse('09/10/2030'),
                                  token: 'PROMOVERAO')
 create(:coupon, token: 'PROMOVERAO001', promotion: promo_verao)
 create(:coupon, token: 'PROMOVERAO002', promotion: promo_verao)

--- a/spec/requests/api_coupon_management_spec.rb
+++ b/spec/requests/api_coupon_management_spec.rb
@@ -58,4 +58,32 @@ describe 'Coupon API' do
       expect(response.body).to include('Cupom não encontrado')
     end
   end
+
+  context 'burn' do
+    it 'succesfully' do
+      coupon = create(:coupon, token: 'PROMONAT001')
+
+      post '/api/v1/coupon_burn', params: { token: 'PROMONAT001' }
+      coupon.reload
+
+      expect(coupon.consumed).to eq true
+      expect(response).to be_ok
+    end
+
+    it 'empty params' do
+      post '/api/v1/coupon_burn', params: {}
+
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(response).to have_http_status(412)
+      expect(body[:message]).to include('Token inválido')
+    end
+
+    it 'invalid params' do
+      post '/api/v1/coupon_burn', params: { token: 'PROMOBF001' }
+
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(response).to have_http_status(412)
+      expect(body[:message]).to include('Token inválido')
+    end
+  end
 end

--- a/spec/requests/api_coupon_management_spec.rb
+++ b/spec/requests/api_coupon_management_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 describe 'Coupon API' do
   context 'validation' do
     it 'successfully' do
-      coupon = create(:coupon)
+      coupon = create(:coupon, token: 'PROMONIVER001')
 
-      get api_v1_path(coupon)
+      get api_v1_path(coupon.token)
 
       expect(response).to have_http_status(:ok)
       body = JSON.parse(response.body, symbolize_names: true)
@@ -21,7 +21,7 @@ describe 'Coupon API' do
       coupon = create(:coupon)
 
       travel_to Time.zone.local(2025, 10, 1, 12, 30, 45) do
-        get api_v1_path(coupon)
+        get api_v1_path(coupon.token)
       end
 
       expect(response).to have_http_status(:ok)
@@ -34,7 +34,7 @@ describe 'Coupon API' do
     it 'coupon already consumed' do
       coupon = create(:coupon, consumed: true)
 
-      get api_v1_path(coupon)
+      get api_v1_path(coupon.token)
 
       expect(response).to have_http_status(:ok)
       body = JSON.parse(response.body, symbolize_names: true)

--- a/spec/requests/api_coupon_management_spec.rb
+++ b/spec/requests/api_coupon_management_spec.rb
@@ -61,7 +61,7 @@ describe 'Coupon API' do
 
   context 'burn' do
     it 'succesfully' do
-      coupon = create(:coupon, token: 'PROMONAT001')
+      coupon = create(:coupon, token: 'PROMONAT001', consumed: false)
 
       post '/api/v1/coupon_burn', params: { token: 'PROMONAT001' }
       coupon.reload
@@ -80,6 +80,16 @@ describe 'Coupon API' do
 
     it 'invalid params' do
       post '/api/v1/coupon_burn', params: { token: 'PROMOBF001' }
+
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(response).to have_http_status(412)
+      expect(body[:message]).to include('Token inválido')
+    end
+
+    it 'consumed coupon' do
+      create(:coupon, token: 'PROMONAT001', consumed: true)
+
+      post '/api/v1/coupon_burn', params: { token: 'PROMONAT001' }
 
       body = JSON.parse(response.body, symbolize_names: true)
       expect(response).to have_http_status(412)


### PR DESCRIPTION
API para queima dos cupom utilizado na matrícula.

Ajuste na API de validação de cupom (token como parâmetro ao invés do id)

Co-authored-by: Eduardo Gris <gris.eduardo@gmail.com>

Fixes #19 