### PR TITLE
Link empresa parceira na home somente logado

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,5 @@
-<%= link_to 'Empresas Parceiras', partner_companies_path %>
 <% if user_signed_in? %>
+  <%= link_to 'Empresas Parceiras', partner_companies_path %>
   <%= link_to 'Promoções', promotions_path %>
   <%= link_to 'Sair', destroy_user_session_path, method: :delete %>
 <% else %>

--- a/spec/features/user_view_partner_companies_spec.rb
+++ b/spec/features/user_view_partner_companies_spec.rb
@@ -7,6 +7,12 @@ feature 'user view partner companies' do
     expect(current_path).to eq new_user_session_path
   end
 
+  scenario 'must be logged in to click on empresas parceiras' do
+    visit root_path
+
+    expect(page).not_to have_content('Empresas Parceiras')
+  end
+
   scenario 'successfully view index' do
     user = create(:user)
 


### PR DESCRIPTION
Consertado bug do link para visualização de empresas parceiras aparecer na home antes do login.

Fixes #29 